### PR TITLE
Hiding Safari UI when a launching from home screen

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -17,6 +17,8 @@
     %meta{:property => "og:site_name", :content => t("titles.main", :thing => t("defaults.thing").titleize)}
     %meta{:property => "og:image", :content => image_url('logos/adopt-a-drain-horizontal.png')}
     %meta{:property => "og:locale", :content => "en_US"}
+    %meta{:name => "apple-mobile-web-app-capable", :content => "yes"}
+    %meta{:name => "apple-mobile-web-app-status-bar-style", :content => "transparent"}
     / HTML5 shim, for IE6-8 support of HTML5 elements
     /[if lt IE 9]
       = javascript_include_tag "//html5shim.googlecode.com/svn/trunk/html5.js"


### PR DESCRIPTION
This removes the Safari UI when app is added to iOS home screen and is launched.  Makes the web app appear like it's a native app.